### PR TITLE
HSC-24: Remove 'Haiti_' prefix and map history and examination concepts to CIEL equivalent

### DIFF
--- a/configuration/concepts/history_and_examination_form.csv
+++ b/configuration/concepts/history_and_examination_form.csv
@@ -1,10 +1,10 @@
 Uuid,Void/Retire,Same as mappings,Fully specified name:en,Short name:en,Description:en,Data class,Data type,Complex data handler,Answers,Members,Allow decimals,Units,Normal low,Normal high,Absolute low,Absolute high,_version:1,_order:1000
 2e1b2486-9fa6-4b23-921e-583f67541731,,,Assessment and Plan,,,Misc,Text,,,,,,,,,,,
-9d59ae86-abe2-4f24-a2fc-f1db2db6287b,,,Allergies,Allergies,,Misc,Text,,,,,,,,,,,
+9d59ae86-abe2-4f24-a2fc-f1db2db6287b,,CIEL:162141,Allergies,Allergies,,Misc,Text,,,,,,,,,,,
 c3949eb6-3f10-11e4-adec-0800271c1b75,,,Chief Complaint Data,Problems,,Concept Details,N/A,,,Chief Complaint; Non-Coded Chief Complaint,,,,,,,,
 4fbf4b32-4411-436c-9c3b-1a907685a0a0,,,Image,Image,,Image,Complex,ImageUrlHandler,,,,,,,,,,
 c3ae29e3-9836-4df9-bcef-8d01b776854d,,,Consultation Images,Consultation Images,,Misc,N/A,,,4fbf4b32-4411-436c-9c3b-1a907685a0a0,,,,,,,,
-c3998f6b-3f10-11e4-adec-0800271c1b75,,,History Notes,History Notes,,Misc,Text,,,,,,,,,,,
+c3998f6b-3f10-11e4-adec-0800271c1b75,,CIEL:160029,History Notes,History Notes,,Misc,Text,,,,,,,,,,,
 c2a43174-c9db-4e54-8516-17372c83537f,,,Smoking History,Smoking History,,Misc,Boolean,,,,,,,,,,,
 c39a35e2-3f10-11e4-adec-0800271c1b75,,,Examination Notes,Examination Notes,,Misc,Text,,,,,,,,,,,
 c393fd1d-3f10-11e4-adec-0800271c1b75,,,History and Examination,History and Examination,,Misc,N/A,,,Chief Complaint Data; History Notes; Allergies; Smoking History; Examination Notes; Assessment and Plan; Consultation Images,,,,,,,,


### PR DESCRIPTION
Fixed History and examination form.
_NOTES_

- Chief complaint data references chief complaint....but couldn't find that concept